### PR TITLE
feat: add timeout option to prompt (Close #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Available options:
 | replace | Replace each character with the specified string when `silent` is true | string | '' |
 | input | Input stream to read from | [Stream](https://nodejs.org/api/process.html#process_process_stdin) | process.stdin |
 | output | Output stream to write to | [Stream](https://nodejs.org/api/process.html#process_process_stdout) | process.stdout |
+| timeout | Timeout in seconds | number | 0 |
 
 The same **options** are available to **all functions** but with different default values.
 
@@ -102,6 +103,26 @@ The same **options** are available to **all functions** but with different defau
         }
     })();
     ```
+
+- Ask for a name with timeout:
+
+    ```js
+    const promptly = require('promptly');
+
+    (async () => {
+        const name = await promptly.prompt('Name [{timeout}s]: ', { timeout: 3 });
+        console.log(name);
+    })();
+    ```
+
+    It will display (on the same line):
+    ```
+    Name [3s]:
+    Name [2s]:
+    Name [1s]:
+    ```
+
+    It throws an `Error("timed out")` if timeout is reached and no default value is provided
 
 #### Validators
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Available options:
 | input | Input stream to read from | [Stream](https://nodejs.org/api/process.html#process_process_stdin) | process.stdin |
 | output | Output stream to write to | [Stream](https://nodejs.org/api/process.html#process_process_stdout) | process.stdout |
 | timeout | Timeout in ms | number | 0 |
-| timeoutToDefault | Return default value if timed out | boolean | false |
+| useDefaultOnTimeout | Return default value if timed out | boolean | false |
 
 The same **options** are available to **all functions** but with different default values.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Available options:
 | input | Input stream to read from | [Stream](https://nodejs.org/api/process.html#process_process_stdin) | process.stdin |
 | output | Output stream to write to | [Stream](https://nodejs.org/api/process.html#process_process_stdout) | process.stdout |
 | timeout | Timeout in ms | number | 0 |
+| timeoutToDefault | Return default value if timed out | boolean | false |
 
 The same **options** are available to **all functions** but with different default values.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Available options:
 | replace | Replace each character with the specified string when `silent` is true | string | '' |
 | input | Input stream to read from | [Stream](https://nodejs.org/api/process.html#process_process_stdin) | process.stdin |
 | output | Output stream to write to | [Stream](https://nodejs.org/api/process.html#process_process_stdout) | process.stdout |
-| timeout | Timeout in seconds | number | 0 |
+| timeout | Timeout in ms | number | 0 |
 
 The same **options** are available to **all functions** but with different default values.
 
@@ -110,16 +110,9 @@ The same **options** are available to **all functions** but with different defau
     const promptly = require('promptly');
 
     (async () => {
-        const name = await promptly.prompt('Name [{timeout}s]: ', { timeout: 3 });
+        const name = await promptly.prompt('Name: ', { timeout: 3000 });
         console.log(name);
     })();
-    ```
-
-    It will display (on the same line):
-    ```
-    Name [3s]:
-    Name [2s]:
-    Name [1s]:
     ```
 
     It throws an `Error("timed out")` if timeout is reached and no default value is provided

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -7,7 +7,7 @@ function getOptions(options) {
         retry: true,
         trim: true,
         default: undefined,
-        timeoutToDefault: false,
+        useDefaultOnTimeout: false,
 
         // `read` package options
         silent: false,

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -13,6 +13,7 @@ function getOptions(options) {
         replace: '',
         input: process.stdin,
         output: process.stdout,
+        timeout: 0,
 
         ...options,
     };

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -7,6 +7,7 @@ function getOptions(options) {
         retry: true,
         trim: true,
         default: undefined,
+        timeoutToDefault: false,
 
         // `read` package options
         silent: false,

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -19,7 +19,7 @@ async function prompt(message, options) {
             timeout: options.timeout,
         });
     } catch (err) {
-        if (err.message !== 'timed out' || !options.default) {
+        if (err.message !== 'timed out' || !options.default || !options.timeoutToDefault) {
             throw err;
         }
         value = options.default;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -19,7 +19,7 @@ async function prompt(message, options) {
             timeout: options.timeout,
         });
     } catch (err) {
-        if (err.message !== 'timed out' || !options.default || !options.timeoutToDefault) {
+        if (err.message !== 'timed out' || !options.default || !options.useDefaultOnTimeout) {
             throw err;
         }
         value = options.default;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -9,42 +9,20 @@ async function prompt(message, options) {
 
     // Read input
     // Manage timeout
-    if (options.timeout) {
-        let timeout = options.timeout;
-
-        do {
-            try {
-                // Use read with 1s timeout to be able to update prompt with remaining time if needed
-                value = await read({
-                    prompt: message.replace(/\{timeout\}/g, timeout),
-                    silent: options.silent,
-                    replace: options.replace,
-                    input: options.input,
-                    output: options.output,
-                    timeout: 1000,
-                });
-                timeout = 0;
-            } catch (err) {
-                if (err.message !== 'timed out') {
-                    throw err;
-                }
-                timeout = timeout - 1;
-                if (timeout <= 0) {
-                    if (options.default === undefined) {
-                        throw new Error('timed out');
-                    }
-                    value = options.default;
-                }
-            }
-        } while (timeout);
-    } else {
+    try {
         value = await read({
             prompt: message,
             silent: options.silent,
             replace: options.replace,
             input: options.input,
             output: options.output,
+            timeout: options.timeout,
         });
+    } catch (err) {
+        if (err.message !== 'timed out' || !options.default) {
+            throw err;
+        }
+        value = options.default;
     }
 
     // Trim?

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -19,7 +19,7 @@ async function prompt(message, options) {
             timeout: options.timeout,
         });
     } catch (err) {
-        if (err.message !== 'timed out' || !options.default || !options.useDefaultOnTimeout) {
+        if (err.message !== 'timed out' || options.default === undefined || !options.useDefaultOnTimeout) {
             throw Object.assign(new Error(err.message), { code: 'TIMEDOUT' });
         }
         value = options.default;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -5,14 +5,47 @@ const { promisify } = require('util');
 const read = promisify(require('read'));
 
 async function prompt(message, options) {
+    let value;
+
     // Read input
-    let value = await read({
-        prompt: message,
-        silent: options.silent,
-        replace: options.replace,
-        input: options.input,
-        output: options.output,
-    });
+    // Manage timeout
+    if (options.timeout) {
+        let timeout = options.timeout;
+
+        do {
+            try {
+                // Use read with 1s timeout to be able to update prompt with remaining time if needed
+                value = await read({
+                    prompt: message.replace(/\{timeout\}/g, timeout),
+                    silent: options.silent,
+                    replace: options.replace,
+                    input: options.input,
+                    output: options.output,
+                    timeout: 1000,
+                });
+                timeout = 0;
+            } catch (err) {
+                if (err.message !== 'timed out') {
+                    throw err;
+                }
+                timeout = timeout - 1;
+                if (timeout <= 0) {
+                    if (options.default === undefined) {
+                        throw new Error('timed out');
+                    }
+                    value = options.default;
+                }
+            }
+        } while (timeout);
+    } else {
+        value = await read({
+            prompt: message,
+            silent: options.silent,
+            replace: options.replace,
+            input: options.input,
+            output: options.output,
+        });
+    }
 
     // Trim?
     if (options.trim) {

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -20,7 +20,7 @@ async function prompt(message, options) {
         });
     } catch (err) {
         if (err.message !== 'timed out' || !options.default || !options.useDefaultOnTimeout) {
-            throw err;
+            throw Object.assign(new Error(err.message), { code: 'TIMEDOUT' });
         }
         value = options.default;
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest --env node --coverage",
+    "test": "jest --env node --coverage --runInBand",
     "prerelease": "npm t && npm run lint",
     "release": "standard-version",
     "postrelease": "git push --follow-tags origin HEAD && npm publish"

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -196,7 +196,7 @@ it('should timeout if user is not fast enough', async () => {
 });
 
 it('should take default value if timed out with timeoutToDefault', async () => {
-    expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop', timeoutToDefault: true })).toEqual('plop');
+    expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop', useDefaultOnTimeout: true })).toEqual('plop');
 });
 
 it('should take default value if timed out', async () => {

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -197,6 +197,7 @@ it('should timeout if user is not fast enough', async () => {
 
 it('should take default value if timed out with timeoutToDefault', async () => {
     expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop', useDefaultOnTimeout: true })).toEqual('plop');
+    expect(await promptly.prompt('prompt: ', { timeout: 10, default: '', useDefaultOnTimeout: true })).toEqual('');
 });
 
 it('should take default value if timed out', async () => {

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -192,18 +192,14 @@ it('should write input using options.replace to stdout if silent is enabled', as
 });
 
 it('should timeout if user is not fast enough', async () => {
-    process.stdout.write.mockClear();
-    await expect(promptly.prompt('prompt: [{timeout}s] ', { timeout: 2 })).rejects.toEqual(new Error('timed out'));
-    expect(writeIndexOf('prompt: [2s] ')).toBe(2);
-    expect(writeIndexOf('prompt: [1s] ')).toBe(6);
-    process.stdout.write.mockClear();
+    await expect(promptly.prompt('prompt: ', { timeout: 10 })).rejects.toEqual(new Error('timed out'));
 });
 
 it('should take default value if timed out', async () => {
-    expect(await promptly.prompt('prompt: [{timeout}s] ', { timeout: 1, default: 'plop' })).toEqual('plop');
+    expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop' })).toEqual('plop');
 });
 
 it('should take input value if not timed out', async () => {
-    sendLine('plop2', 300);
-    expect(await promptly.prompt('prompt: [{timeout}s] ', { timeout: 2, default: 'plop' })).toEqual('plop2');
+    sendLine('plop2', 10);
+    expect(await promptly.prompt('prompt: ', { timeout: 20, default: 'plop' })).toEqual('plop2');
 });

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -195,8 +195,12 @@ it('should timeout if user is not fast enough', async () => {
     await expect(promptly.prompt('prompt: ', { timeout: 10 })).rejects.toEqual(new Error('timed out'));
 });
 
+it('should take default value if timed out with timeoutToDefault', async () => {
+    expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop', timeoutToDefault: true })).toEqual('plop');
+});
+
 it('should take default value if timed out', async () => {
-    expect(await promptly.prompt('prompt: ', { timeout: 10, default: 'plop' })).toEqual('plop');
+    await expect(promptly.prompt('prompt: ', { timeout: 10, default: 'plop' })).rejects.toEqual(new Error('timed out'));
 });
 
 it('should take input value if not timed out', async () => {

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -190,3 +190,20 @@ it('should write input using options.replace to stdout if silent is enabled', as
     expect(process.stdout.write).toHaveBeenCalledWith('a');
     expect(process.stdout.write).not.toHaveBeenCalledWith('z');
 });
+
+it('should timeout if user is not fast enough', async () => {
+    process.stdout.write.mockClear();
+    await expect(promptly.prompt('prompt: [{timeout}s] ', { timeout: 2 })).rejects.toEqual(new Error('timed out'));
+    expect(writeIndexOf('prompt: [2s] ')).toBe(2);
+    expect(writeIndexOf('prompt: [1s] ')).toBe(6);
+    process.stdout.write.mockClear();
+});
+
+it('should take default value if timed out', async () => {
+    expect(await promptly.prompt('prompt: [{timeout}s] ', { timeout: 1, default: 'plop' })).toEqual('plop');
+});
+
+it('should take input value if not timed out', async () => {
+    sendLine('plop2', 300);
+    expect(await promptly.prompt('prompt: [{timeout}s] ', { timeout: 2, default: 'plop' })).toEqual('plop2');
+});


### PR DESCRIPTION
I implemented the timeout function
I was not able to emulate Ctrl+C to catch line 27 of prompt.js, if you have an idea, I'll update the test.

The options.timeout is in seconds, and you can use a {timeout} variable in the prompt to display, the remaining seconds before timeout.

I had to add the --runInBand to avoid interference on process.stdin/out by several tests, as timeout tests take several seconds.